### PR TITLE
Configure Android build on PR

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -1,0 +1,21 @@
+name: Android Build
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Build with Gradle
+      run: ./gradlew assemble


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs `./gradlew assemble` when a pull request targets `main`
- switch to JDK 17

## Testing
- `python -m py_compile playtime.py`


------
https://chatgpt.com/codex/tasks/task_e_684d2c6a89188325a1e3cabc2b652e4b